### PR TITLE
Add generic Keyboard component to avoid code duplication

### DIFF
--- a/src/react-event-components/KeyDown.js
+++ b/src/react-event-components/KeyDown.js
@@ -1,33 +1,8 @@
-const { Component, PropTypes } = require('react')
+const React = require('react')
+const { PropTypes } = React
+const KeyEvent = require('./KeyEvent')
 
-class KeyDown extends Component {
-  constructor() {
-    super()
-    this.listen = this.listen.bind(this)
-  }
-
-  listen(event) {
-    if (event.key === this.props.when) {
-      this.props.do()
-    }
-  }
-
-  componentDidMount() {
-    document.addEventListener('keydown', this.listen)
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.listen)
-  }
-
-  shouldComponentUpdate() {
-    return false
-  }
-
-  render() {
-    return null
-  }
-}
+const KeyDown = (props) => <KeyEvent trigger="keydown" {...props} />
 
 KeyDown.propTypes = {
   /**

--- a/src/react-event-components/KeyEvent.js
+++ b/src/react-event-components/KeyEvent.js
@@ -1,0 +1,50 @@
+const { Component, PropTypes } = require('react')
+
+class KeyEvent extends Component {
+  constructor(props) {
+    super(props)
+    this.listen = this.listen.bind(this)
+  }
+
+  listen(event) {
+    if (event.key === this.props.when) {
+      console.log(this.props.trigger)
+      this.props.do()
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener(this.props.trigger, this.listen)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener(this.props.trigger, this.listen)
+  }
+
+  shouldComponentUpdate() {
+    return false
+  }
+
+  render() {
+    return null
+  }
+}
+
+KeyEvent.propTypes = {
+  /**
+   * A trigger to add listeners to
+   */
+  trigger: PropTypes.string.isRequired,
+  /**
+   * A keyboard key to trigger the callback
+   * @type {String}
+   */
+  when: PropTypes.string.isRequired,
+  /**
+   * Triggered when the key is pressed
+   * @type {Function}
+   */
+  do: PropTypes.func.isRequired
+}
+
+module.exports = KeyEvent

--- a/src/react-event-components/KeyUp.js
+++ b/src/react-event-components/KeyUp.js
@@ -1,33 +1,8 @@
-const { Component, PropTypes } = require('react')
+const React = require('react')
+const { PropTypes } = React
+const KeyEvent = require('./KeyEvent')
 
-class KeyUp extends Component {
-  constructor() {
-    super()
-    this.listen = this.listen.bind(this)
-  }
-
-  listen(event) {
-    if (event.key === this.props.when) {
-      this.props.do()
-    }
-  }
-
-  componentDidMount() {
-    document.addEventListener('keyup', this.listen)
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keyup', this.listen)
-  }
-
-  shouldComponentUpdate() {
-    return false
-  }
-
-  render() {
-    return null
-  }
-}
+const KeyUp = (props) => <KeyEvent trigger="keyup" {...props} />
 
 KeyUp.propTypes = {
   /**
@@ -36,7 +11,7 @@ KeyUp.propTypes = {
    */
   when: PropTypes.string.isRequired,
   /**
-   * Triggered when the key is released
+   * Triggered when the key is pressed
    * @type {Function}
    */
   do: PropTypes.func.isRequired


### PR DESCRIPTION
## Description

At the moment, the only difference between `KeyUp` and `KeyDown` are the events they are attached to (`keyup`, and `keydown`, respectively).

This PR creates a new generic component for keyboard events called `Keyboard`, that can be used by the other components passing their specific trigger to `Keyboard`.