### PR TITLE
Remove Git dirty check from prepublish hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "demo-deploy": "npm run demo-build && gh-pages -d ./build",
     "test": "react-scripts test --env=jsdom",
     "build": "webpack --progress --colors",
-    "prepublish": "npm run build && git diff --quiet"
+    "prepublish": "npm run build"
   }
 }


### PR DESCRIPTION
This isn't working very well for Travis builds, given that `prepublish` hook is called after `npm install`, making the working branch dirty for PRs that change the library build. This PR removes the dirty check from `package.json`.